### PR TITLE
Drag and drop to move tasks around

### DIFF
--- a/calcutron/forms.py
+++ b/calcutron/forms.py
@@ -15,7 +15,9 @@ class DeleteTaskForm(forms.Form):
 
 class EditTaskForm(forms.Form):
     id = forms.IntegerField()
-    title = forms.CharField(max_length=255)
+    title = forms.CharField(max_length=255, required=False)
+    parent = forms.IntegerField(required=False)
+    sort_order = forms.IntegerField(required=False)
 
 
 class SetDoneTaskForm(forms.Form):

--- a/calcutron/migrations/0004_set_sort_orders.py
+++ b/calcutron/migrations/0004_set_sort_orders.py
@@ -1,0 +1,18 @@
+
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('calcutron', '0003_task_users'),
+    ]
+
+    def set_sort_orders(apps, schema_editor):
+        Task = apps.get_model("calcutron", "Task")
+        Task.objects.update(sort_order=models.F("pk"))
+
+    operations = [
+        migrations.RunPython(set_sort_orders, migrations.RunPython.noop),
+    ]

--- a/calcutron/static/styles/tasks.less
+++ b/calcutron/static/styles/tasks.less
@@ -152,25 +152,32 @@
                         min-height: 35px;
                     }
 
-                    .dropzone {
+                    .dropzone-container {
                         position: absolute;
                         left: 0;
+                        top: -5px;
                         width: 100%;
+                        height: calc(100% + 10px);
+
                         z-index: 1;
 
-                        &.before {
-                            top: 0;
-                            height: 25%;
-                        }
+                        display: flex;
+                        flex-flow: column;
 
-                        &.mid {
-                            top: 25%;
-                            height: 50%;
-                        }
+                        .dropzone {
+                            width: 100%;
 
-                        &.after {
-                            top: 75%;
-                            height: 25%;
+                            &.highlight {
+                                background-color: rgba(255, 255, 255, 0.3);
+                            }
+
+                            &.before, &.after {
+                                height: 25%;
+                            }
+
+                            &.in {
+                                height: 50%;
+                            }
                         }
                     }
                 }

--- a/calcutron/static/styles/tasks.less
+++ b/calcutron/static/styles/tasks.less
@@ -61,7 +61,6 @@
 
             li.task-wrapper {
                 width: 100%;
-                position: relative;
 
                 .main-row {
                     display: flex;
@@ -69,8 +68,8 @@
                     align-items: flex-start;
                     justify-content: center;
 
+                    position: relative;
                     user-select: none;
-                    z-index: 0;
 
                     min-height: 35px;
                     width: 100%;
@@ -80,6 +79,8 @@
                         height: 30px;
                         margin-right: 8px;
                         flex: 0 0 auto;
+
+                        z-index: 0;
 
                         input {
                             width: 100%;
@@ -98,6 +99,7 @@
 
                         padding: 0 8px;
                         cursor: pointer;
+                        z-index: 0;
 
                         .caret-wrapper {
                             display: flex;
@@ -142,33 +144,34 @@
 
                         margin: 5px 0;
                         padding-left: 30px;
+                        z-index: 0;
                     }
 
                     .title, .options-row > * {
                         margin-right: 8px;
                         min-height: 35px;
                     }
-                }
 
-                .dropzone {
-                    position: absolute;
-                    left: 0;
-                    width: 100%;
-                    z-index: 1;
+                    .dropzone {
+                        position: absolute;
+                        left: 0;
+                        width: 100%;
+                        z-index: 1;
 
-                    &.before {
-                        top: 0;
-                        height: 25%;
-                    }
+                        &.before {
+                            top: 0;
+                            height: 25%;
+                        }
 
-                    &.mid {
-                        top: 25%;
-                        height: 50%;
-                    }
+                        &.mid {
+                            top: 25%;
+                            height: 50%;
+                        }
 
-                    &.after {
-                        top: 75%;
-                        height: 25%;
+                        &.after {
+                            top: 75%;
+                            height: 25%;
+                        }
                     }
                 }
             }

--- a/calcutron/static/styles/tasks.less
+++ b/calcutron/static/styles/tasks.less
@@ -61,12 +61,16 @@
 
             li.task-wrapper {
                 width: 100%;
+                position: relative;
 
                 .main-row {
                     display: flex;
                     flex-flow: column;
                     align-items: flex-start;
                     justify-content: center;
+
+                    user-select: none;
+                    z-index: 0;
 
                     min-height: 35px;
                     width: 100%;
@@ -143,6 +147,28 @@
                     .title, .options-row > * {
                         margin-right: 8px;
                         min-height: 35px;
+                    }
+                }
+
+                .dropzone {
+                    position: absolute;
+                    left: 0;
+                    width: 100%;
+                    z-index: 1;
+
+                    &.before {
+                        top: 0;
+                        height: 25%;
+                    }
+
+                    &.mid {
+                        top: 25%;
+                        height: 50%;
+                    }
+
+                    &.after {
+                        top: 75%;
+                        height: 25%;
                     }
                 }
             }

--- a/calcutron/views.py
+++ b/calcutron/views.py
@@ -14,7 +14,7 @@ def task_to_dict(task):
         "parent": task.parent_id,
         "title": task.title,
         "long_text": task.long_text,
-        "order": task.sort_order,
+        "sort_order": task.sort_order,
         "done": task.done,
     }
 

--- a/calcutron/views.py
+++ b/calcutron/views.py
@@ -84,7 +84,17 @@ class EditTaskView(AjaxTaskView):
 
     def resolve_form(self, form):
         self.object = self.model.objects.get(id=form.cleaned_data["id"])
-        self.object.title = form.cleaned_data["title"]
+        data = form.cleaned_data
+
+        if "title" in data and data["title"]:
+            self.object.title = data["title"]
+
+        if "parent" in data and data["parent"]:
+            self.object.parent_id = data["parent"]
+
+        if "sort_order" in data and data["sort_order"]:
+            self.object.sort_order = data["sort_order"]
+
         self.object.save()
 
 

--- a/react/actions.js
+++ b/react/actions.js
@@ -50,7 +50,7 @@ function deleteTask(task) {
 }
 
 
-function updateTask(title, task) {
+function setTaskTitle(task, title) {
     let data = {
         id: task.id,
         title: title,
@@ -62,7 +62,7 @@ function updateTask(title, task) {
 }
 
 
-function setDoneTask(done, task) {
+function setTaskDone(task, done) {
     let data = {
         id: task.id,
         done: done,
@@ -74,9 +74,35 @@ function setDoneTask(done, task) {
 }
 
 
+function setTaskParent(task, new_parent_id) {
+    let data = {
+        id: task.id,
+        parent: new_parent_id,
+    };
+
+    ajax_requests.post("/edit", data, () => {});
+}
+
+
+function moveTask(task, new_sort_order, new_parent=undefined) {
+    let data = {
+        id: task.id,
+        sort_order: new_sort_order,
+    };
+
+    if (new_parent !== undefined) {
+        data.parent = new_parent
+    }
+
+    ajax_requests.post("/edit", data, () => {});
+}
+
+
 export default {
     addTask,
     deleteTask,
-    updateTask,
-    setDoneTask,
+    setTaskTitle,
+    setTaskDone,
+    setTaskParent,
+    moveTask,
 }

--- a/react/desktop_ui.js
+++ b/react/desktop_ui.js
@@ -39,7 +39,7 @@ import tab_container from "./tab_container";
     update() {
         let field_element = $(this.title_field_ref.current);
 
-        actions.updateTask(field_element.val(), taskState.tasks[taskState.active_tab]);
+        actions.setTaskTitle(taskState.tasks[taskState.active_tab], field_element.val());
         field_element.val("");
     }
 

--- a/react/state.js
+++ b/react/state.js
@@ -1,4 +1,5 @@
 import {action, observable, transaction} from "mobx";
+import actions from "./actions";
 
 
 class TaskState {
@@ -96,10 +97,17 @@ class TaskState {
     }
 
 
+    @action.bound
+    setSortOrder(task, new_value, new_parent=undefined) {
+        task.sort_order = new_value;
+        actions.moveTask(task, new_value, new_parent);
+    }
+
+
     // Move a task into another parent, and set its sort_order to be at the end of that parent's
     // list of children.
     @action.bound
-    setTaskParent(task, target_parent) {
+    setTaskParent(task, target_parent, skip_save=false) {
         // If `task` is an ancestor of `target_parent`, do nothing - we don't want to move a task
         // inside itself.
         if (this.isAncestor(target_parent, task)) {
@@ -118,6 +126,11 @@ class TaskState {
         delete original_parent.children[task.id];
         target_parent.children[task.id] = task;
         task.parent = target_parent.id;
+
+        // Tell the API about the changes - both to the sort order and to the parent.
+        if (!skip_save) {
+            this.setSortOrder(task, max_sort_order + 1, target_parent.id);
+        }
     }
 
 
@@ -134,7 +147,7 @@ class TaskState {
         // If the task being moved isn't in the same level of the hierarchy as the target,
         // update that first.
         if (task.parent !== target_task.parent) {
-            this.setTaskParent(task, target_parent);
+            this.setTaskParent(task, target_parent, true);
         }
 
         let new_sort_order = target_task.sort_order;
@@ -144,22 +157,23 @@ class TaskState {
             // move the target and everything in between the two down by one.
             for (let child of Object.values(target_parent.children)) {
                 if (child.sort_order < task.sort_order && child.sort_order >= target_task.sort_order) {
-                    child.sort_order++;
+                    this.setSortOrder(child, child.sort_order + 1);
                 }
             }
+
         } else {
             // If the task being moved is currently above the target task,
             // move everything between the two (but *not* the target) up by one.
             // Also decrement new_sort_order, so that the moved task comes in above target_task.
             for (let child of Object.values(target_parent.children)) {
                 if (child.sort_order > task.sort_order && child.sort_order < target_task.sort_order) {
-                    child.sort_order--;
+                    this.setSortOrder(child, child.sort_order - 1);
                 }
             }
             new_sort_order--;
         }
 
-        task.sort_order = new_sort_order;
+        this.setSortOrder(task, new_sort_order, task.parent);
     }
 
 
@@ -176,35 +190,33 @@ class TaskState {
         // If the task being moved isn't in the same level of the hierarchy as the target,
         // update that first.
         if (task.parent !== target_task.parent) {
-            this.setTaskParent(task, target_parent);
-            console.log(task.sort_order);
+            this.setTaskParent(task, target_parent, true);
         }
 
         let new_sort_order = target_task.sort_order;
 
         if (task.sort_order > target_task.sort_order) {
-            console.log("is below");
             // If the task being moved is currently below the target task,
             // move everything in between the two (but not the target) down by one.
             // Also increment new_sort_order, so that the moved task comes in below target_task.
             for (let child of Object.values(target_parent.children)) {
                 if (child.sort_order < task.sort_order && child.sort_order > target_task.sort_order) {
-                    child.sort_order++;
+                    this.setSortOrder(child, child.sort_order + 1);
                 }
             }
             new_sort_order++;
+
         } else {
-            console.log("is above");
             // If the task being moved is currently above the target task,
             // move the target and everything between the two up by one.
             for (let child of Object.values(target_parent.children)) {
                 if (child.sort_order > task.sort_order && child.sort_order <= target_task.sort_order) {
-                    child.sort_order--;
+                    this.setSortOrder(child, child.sort_order - 1);
                 }
             }
         }
 
-        task.sort_order = new_sort_order;
+        this.setSortOrder(task, new_sort_order, task.parent);
     }
 }
 

--- a/react/state.js
+++ b/react/state.js
@@ -1,4 +1,4 @@
-import {observable, transaction} from "mobx";
+import {action, observable, transaction} from "mobx";
 
 
 class TaskState {
@@ -17,6 +17,7 @@ class TaskState {
         parent: null,
         children: {},
     });
+
 
     initialise(tasks) {
         transaction(() => {
@@ -46,6 +47,8 @@ class TaskState {
         });
     }
 
+
+    @action.bound
     addTask(parent_id, task_data) {
         if (parent_id === null) {
             return this.addRootTask(task_data);
@@ -61,6 +64,8 @@ class TaskState {
         return new_task;
     }
 
+
+    @action.bound
     addRootTask(task_data) {
         task_data = Object.assign({}, this.tasks_base, task_data, {parent: null});
         this.tasks[task_data.id] = task_data;
@@ -75,37 +80,64 @@ class TaskState {
         return new_task;
     }
 
+
+    isAncestor(task, potential_ancestor) {
+        // Return true iff `potential_ancestor` is above `task` in the tree, or is `task` itself.
+        let parent_id = task.id;
+        while (parent_id !== null) {
+            if (parent_id === potential_ancestor.id) {
+                return true;
+            }
+
+            parent_id = this.tasks_by_id[parent_id].parent;
+        }
+
+        return false;
+    }
+
+
+    // Move a task into another parent, and set its sort_order to be at the end of that parent's
+    // list of children.
+    @action.bound
     setTaskParent(task, target_parent) {
-        // Move a task into another parent, and set its sort_order to be at the end of that parent's
-        // list of children.
-        let original_parent = this.tasks_by_id[task.parent];
-        if (target_parent === original_parent) {
+        // If `task` is an ancestor of `target_parent`, do nothing - we don't want to move a task
+        // inside itself.
+        if (this.isAncestor(target_parent, task)) {
             return;
         }
 
-        delete original_parent.children[task.id];
-        target_parent.children[task.id] = task;
-        task.parent = target_parent.id;
-
+        // Set the moved task's sort_order to be after those of its new siblings.
         let max_sort_order = 0;
-        for (let child in Object.values(target_parent.children)) {
+        for (let child of Object.values(target_parent.children)) {
             max_sort_order = Math.max(max_sort_order, child.sort_order);
         }
         task.sort_order = max_sort_order + 1;
+
+        // Move `task` from its parent's set of children to `target_parent`'s set of children.
+        let original_parent = this.tasks_by_id[task.parent];
+        delete original_parent.children[task.id];
+        target_parent.children[task.id] = task;
+        task.parent = target_parent.id;
     }
 
+
+    @action.bound
     moveTaskBefore(task, target_task) {
+        // If `task` is an ancestor of `target_task`, do nothing - we don't want to move a task
+        // inside itself.
+        if (this.isAncestor(target_task, task)) {
+            return;
+        }
+
         let target_parent = this.tasks_by_id[target_task.parent];
 
+        // If the task being moved isn't in the same level of the hierarchy as the target,
+        // update that first.
         if (task.parent !== target_task.parent) {
             this.setTaskParent(task, target_parent);
         }
 
-        if (task.id === target_task.id) {
-            return;
-        }
-
-        let new_sort_order = target_task.sort_order - 1;
+        let new_sort_order = target_task.sort_order;
 
         if (task.sort_order > target_task.sort_order) {
             // If the task being moved is currently below the target task,
@@ -118,38 +150,51 @@ class TaskState {
         } else {
             // If the task being moved is currently above the target task,
             // move everything between the two (but *not* the target) up by one.
+            // Also decrement new_sort_order, so that the moved task comes in above target_task.
             for (let child of Object.values(target_parent.children)) {
                 if (child.sort_order > task.sort_order && child.sort_order < target_task.sort_order) {
                     child.sort_order--;
                 }
             }
+            new_sort_order--;
         }
 
         task.sort_order = new_sort_order;
     }
 
+
+    @action.bound
     moveTaskAfter(task, target_task) {
-        let target_parent = this.tasks_by_id[target_task.parent];
-
-        if (task.parent !== target_task.parent) {
-            this.setTaskParent(task, target_parent);
-        }
-
-        if (task.id === target_task.id) {
+        // If `task` is an ancestor of `target_task`, do nothing - we don't want to move a task
+        // inside itself.
+        if (this.isAncestor(target_task, task)) {
             return;
         }
 
-        let new_sort_order = target_task.sort_order + 1;
+        let target_parent = this.tasks_by_id[target_task.parent];
+
+        // If the task being moved isn't in the same level of the hierarchy as the target,
+        // update that first.
+        if (task.parent !== target_task.parent) {
+            this.setTaskParent(task, target_parent);
+            console.log(task.sort_order);
+        }
+
+        let new_sort_order = target_task.sort_order;
 
         if (task.sort_order > target_task.sort_order) {
+            console.log("is below");
             // If the task being moved is currently below the target task,
             // move everything in between the two (but not the target) down by one.
+            // Also increment new_sort_order, so that the moved task comes in below target_task.
             for (let child of Object.values(target_parent.children)) {
                 if (child.sort_order < task.sort_order && child.sort_order > target_task.sort_order) {
                     child.sort_order++;
                 }
             }
+            new_sort_order++;
         } else {
+            console.log("is above");
             // If the task being moved is currently above the target task,
             // move the target and everything between the two up by one.
             for (let child of Object.values(target_parent.children)) {

--- a/react/state.js
+++ b/react/state.js
@@ -6,13 +6,14 @@ class TaskState {
     @observable tasks_by_id = {};
     @observable active_tab = null;
     @observable is_mobile = false;
+    @observable dragged_item = null;
     csrf = null;
 
     tasks_base = Object.freeze({
         title: "",
         long_text: null,
         id: null,
-        order: null,
+        sort_order: null,
         parent: null,
         children: {},
     });
@@ -72,6 +73,93 @@ class TaskState {
         }
 
         return new_task;
+    }
+
+    setTaskParent(task, target_parent) {
+        // Move a task into another parent, and set its sort_order to be at the end of that parent's
+        // list of children.
+        let original_parent = this.tasks_by_id[task.parent];
+        if (target_parent === original_parent) {
+            return;
+        }
+
+        delete original_parent.children[task.id];
+        target_parent.children[task.id] = task;
+        task.parent = target_parent.id;
+
+        let max_sort_order = 0;
+        for (let child in Object.values(target_parent.children)) {
+            max_sort_order = Math.max(max_sort_order, child.sort_order);
+        }
+        task.sort_order = max_sort_order + 1;
+    }
+
+    moveTaskBefore(task, target_task) {
+        let target_parent = this.tasks_by_id[target_task.parent];
+
+        if (task.parent !== target_task.parent) {
+            this.setTaskParent(task, target_parent);
+        }
+
+        if (task.id === target_task.id) {
+            return;
+        }
+
+        let new_sort_order = target_task.sort_order - 1;
+
+        if (task.sort_order > target_task.sort_order) {
+            // If the task being moved is currently below the target task,
+            // move the target and everything in between the two down by one.
+            for (let child of Object.values(target_parent.children)) {
+                if (child.sort_order < task.sort_order && child.sort_order >= target_task.sort_order) {
+                    child.sort_order++;
+                }
+            }
+        } else {
+            // If the task being moved is currently above the target task,
+            // move everything between the two (but *not* the target) up by one.
+            for (let child of Object.values(target_parent.children)) {
+                if (child.sort_order > task.sort_order && child.sort_order < target_task.sort_order) {
+                    child.sort_order--;
+                }
+            }
+        }
+
+        task.sort_order = new_sort_order;
+    }
+
+    moveTaskAfter(task, target_task) {
+        let target_parent = this.tasks_by_id[target_task.parent];
+
+        if (task.parent !== target_task.parent) {
+            this.setTaskParent(task, target_parent);
+        }
+
+        if (task.id === target_task.id) {
+            return;
+        }
+
+        let new_sort_order = target_task.sort_order + 1;
+
+        if (task.sort_order > target_task.sort_order) {
+            // If the task being moved is currently below the target task,
+            // move everything in between the two (but not the target) down by one.
+            for (let child of Object.values(target_parent.children)) {
+                if (child.sort_order < task.sort_order && child.sort_order > target_task.sort_order) {
+                    child.sort_order++;
+                }
+            }
+        } else {
+            // If the task being moved is currently above the target task,
+            // move the target and everything between the two up by one.
+            for (let child of Object.values(target_parent.children)) {
+                if (child.sort_order > task.sort_order && child.sort_order <= target_task.sort_order) {
+                    child.sort_order--;
+                }
+            }
+        }
+
+        task.sort_order = new_sort_order;
     }
 }
 

--- a/react/task.js
+++ b/react/task.js
@@ -131,7 +131,7 @@ import taskState from "./state";
                     <input type="checkbox" checked={this.props.task.done} readOnly={true} />
                 </div>
 
-                <span>{this.props.task.title}</span>
+                <span>{this.props.task.sort_order} {this.props.task.title}</span>
 
                 {Object.keys(this.props.task.children).length > 0 &&
                     <div className="caret-wrapper">
@@ -173,7 +173,7 @@ import taskState from "./state";
         }
 
         return (
-            <div class="dropzone-container">
+            <div className="dropzone-container">
                 <TaskDropzone key="before" zoneType="before" task={this.props.task} />
                 <TaskDropzone key="in" zoneType="in" task={this.props.task} />
                 <TaskDropzone key="after" zoneType="after" task={this.props.task} />
@@ -216,6 +216,7 @@ import taskState from "./state";
 @observer class TaskDropzone extends React.Component {
     constructor(props) {
         super(props);
+
         this.state = {
             highlight: false,
         };
@@ -223,23 +224,13 @@ import taskState from "./state";
 
 
     drop() {
-        let this_task = this.props.task;
-        let dropped_task = taskState.dragged_item;
+        let operations = {
+            "before": taskState.moveTaskBefore,
+            "in": taskState.setTaskParent,
+            "after": taskState.moveTaskAfter,
+        }
 
-        transaction(() => {
-            if (this.props.zoneType === "before") {
-                taskState.moveTaskBefore(dropped_task, this_task);
-            }
-
-            else if (this.props.zoneType === "in") {
-                taskState.setTaskParent(dropped_task, this_task);
-            }
-
-            else {
-                taskState.moveTaskAfter(dropped_task, this_task);
-            }
-        });
-
+        operations[this.props.zoneType](taskState.dragged_item, this.props.task);
         taskState.dragged_item = null;
     }
 

--- a/react/task.js
+++ b/react/task.js
@@ -38,7 +38,9 @@ import taskState from "./state";
         return (
             <ul className="child-tasks">
                 {children.map(child => (
-                    <TaskWrapper key={child.id} task={child} />
+                    <li key={child.id} className="task-wrapper">
+                        <Task key="task" task={child} />
+                    </li>
                 ))}
 
                 <li key="add-form" className="task-form-wrapper">
@@ -51,7 +53,20 @@ import taskState from "./state";
 }
 
 
-@observer class TaskWrapper extends React.Component {
+@observer class Task extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.edit_field_ref = React.createRef();
+
+        this.state = {
+            show_children: false,
+            show_options: false,
+            edit_mode: false,
+        }
+    }
+
+
     dragStart() {
         taskState.dragged_item = this.props.task;
     }
@@ -79,60 +94,6 @@ import taskState from "./state";
         });
 
         taskState.dragged_item = null;
-    }
-
-    renderSingleDropzone(key) {
-        return (
-            <div
-                className={"dropzone " + key}
-                key={key}
-                onDrop={this.drop.bind(this, key)}
-                onDragOver={(event) => event.preventDefault()}
-            />
-        );
-    }
-
-    renderDropzones() {
-        if (taskState.dragged_item === null) {
-            return null;
-        }
-
-        return [
-            this.renderSingleDropzone("before"),
-            this.renderSingleDropzone("mid"),
-            this.renderSingleDropzone("after"),
-        ];
-    }
-
-    render() {
-        let task = this.props.task;
-
-        return (
-            <li key={task.id}
-                draggable={true}
-                className="task-wrapper"
-                onDragStart={this.dragStart.bind(this)}
-                onDragEnd={this.dragEnd.bind(this)}
-            >
-                <Task key="task" task={task} />
-                {this.renderDropzones()}
-            </li>
-        );
-    }
-}
-
-
-@observer class Task extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.edit_field_ref = React.createRef();
-
-        this.state = {
-            show_children: false,
-            show_options: false,
-            edit_mode: false,
-        }
     }
 
     toggleChildren() {
@@ -228,15 +189,59 @@ import taskState from "./state";
         );
     }
 
+    renderSingleDropzone(key) {
+        return (
+            <div
+                className={"dropzone " + key}
+                key={key}
+                onDrop={this.drop.bind(this, key)}
+                onDragOver={(event) => event.preventDefault()}
+            />
+        );
+    }
+
+    renderDropzones() {
+        if (taskState.dragged_item === null) {
+            return null;
+        }
+
+        return [
+            this.renderSingleDropzone("before"),
+            this.renderSingleDropzone("mid"),
+            this.renderSingleDropzone("after"),
+        ];
+    }
+
+    render() {
+        let task = this.props.task;
+
+        return (
+            <li key={task.id}
+            >
+                <Task key="task" task={task} />
+            </li>
+        );
+    }
+
     render() {
         let main_row = (
-            <div key="main-row" className="main-row">
-                {this.state.edit_mode
+            <div
+                key="main-row"
+                className="main-row"
+                draggable={true}
+                onDragStart={this.dragStart.bind(this)}
+                onDragEnd={this.dragEnd.bind(this)}
+            >
+                {this.state.edit_mode && (taskState.dragged_item === null)
                     ? this.renderEditForm()
                     : this.renderTitle()
                 }
 
-                {this.state.show_options && this.renderOptions()}
+                {this.state.show_options && (taskState.dragged_item === null)
+                    && this.renderOptions()
+                }
+
+                {this.renderDropzones()}
             </div>
         );
 

--- a/react/task.js
+++ b/react/task.js
@@ -104,13 +104,13 @@ import taskState from "./state";
 
     edit() {
         let field_element = $(this.edit_field_ref.current);
-        actions.updateTask(field_element.val(), this.props.task);
+        actions.setTaskTitle(this.props.task, field_element.val());
         this.closeOptionsAndEdit();
     }
 
     toggleDone(event) {
         event.stopPropagation();
-        actions.setDoneTask(!this.props.task.done, this.props.task);
+        actions.setTaskDone(!this.props.task.done, this.props.task);
     }
 
     handleEnter(event) {
@@ -131,7 +131,7 @@ import taskState from "./state";
                     <input type="checkbox" checked={this.props.task.done} readOnly={true} />
                 </div>
 
-                <span>{this.props.task.sort_order} {this.props.task.title}</span>
+                <span>{this.props.task.title}</span>
 
                 {Object.keys(this.props.task.children).length > 0 &&
                     <div className="caret-wrapper">


### PR DESCRIPTION
Haven't done dragging between tabs yet, but this implements moving tasks about within a list, and moving them into/out of subtasks.

Unsure how it'll affect the mobile UI - we'll see once it's deployed, I guess.