### PR TITLE
Improve behaviour when the user's session has expired

### DIFF
--- a/calcutron/urls.py
+++ b/calcutron/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path("accounts/", include("django.contrib.auth.urls")),
 
     path("", views.MainView.as_view(), name="main"),
+    path("health_check", views.LoginHealthCheck.as_view(), name="health_check"),
     path("get_tasks", views.GetAllTasksView.as_view(), name="get_tasks"),
     path("new", views.NewTaskView.as_view(), name="new"),
     path("delete", views.DeleteTaskView.as_view(), name="delete"),

--- a/calcutron/views.py
+++ b/calcutron/views.py
@@ -22,6 +22,15 @@ class MainView(LoginRequiredMixin, TemplateView):
     template_name = "calcutron/main.html"
 
 
+class LoginHealthCheck(LoginRequiredMixin, View):
+    """
+    A basic healthcheck endpoint. The frontend can poll this, and will receive a redirect to the
+    login page if the user's session has lapsed.
+    """
+    def get(self, request, *args, **kwargs):
+        return JsonResponse({"success": True})
+
+
 class GetAllTasksView(LoginRequiredMixin, View):
     def get(self, request, *args, **kwargs):
         tasks = list(Task.objects.filter(parent=None, users=request.user))

--- a/react/ajax_requests.js
+++ b/react/ajax_requests.js
@@ -3,6 +3,17 @@ import $ from "jquery";
 import taskState from "./state";
 
 
+function get(url, success_callback) {
+    $.get(url, {}, (return_data) => {
+        if (return_data.errors) {
+            alert(Object.values(return_data.errors));
+        } else {
+            success_callback(return_data);
+        }
+    });
+}
+
+
 function post(url, data, success_callback) {
     let full_data = Object.assign({csrfmiddlewaretoken: taskState.csrf}, data);
 
@@ -17,5 +28,6 @@ function post(url, data, success_callback) {
 
 
 export default {
+    get,
     post,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==3.2.18
+django==3.2.23
 django-extensions==3.2.1
 django-heroku==0.3.1
 django-orderable==6.1.1


### PR DESCRIPTION
Sometimes, the user becomes logged out without realising, types a long post, and it fails. This PR adds a health check endpoint (which returns a redirect to the login page if they're unauthenticated) and polls it regularly while the app is focused, as well as immediately when they come to the page.