### PR TITLE
Add React Router and use it for task navigation

### DIFF
--- a/calcutron/urls.py
+++ b/calcutron/urls.py
@@ -12,13 +12,15 @@ urlpatterns = [
     path("admin/", admin.site.urls, name="admin"),
     path("accounts/", include("django.contrib.auth.urls")),
 
-    path("", views.MainView.as_view(), name="main"),
     path("health_check", views.LoginHealthCheck.as_view(), name="health_check"),
     path("get_tasks", views.GetAllTasksView.as_view(), name="get_tasks"),
     path("new", views.NewTaskView.as_view(), name="new"),
     path("delete", views.DeleteTaskView.as_view(), name="delete"),
     path("edit", views.EditTaskView.as_view(), name="edit"),
     path("done", views.SetDoneTaskView.as_view(), name="done"),
+
+    path("", views.MainView.as_view(), name="main"),
+    path("<int:task_id>", views.MainView.as_view(), name="main_with_task_id"),
 ]
 
 urlpatterns += staticfiles_urlpatterns()

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "mobx-react": "^6.1.4",
     "react": "^16.11.0",
     "react-contextmenu": "^2.14.0",
-    "react-dom": "^16.11.0"
+    "react-dom": "^16.11.0",
+    "react-router": "^6.20.1",
+    "react-router-dom": "^6.20.1"
   },
   "scripts": {
     "dev": "webpack --mode development ./react/main.js --output ./calcutron/static/js/react.js --config webpack.dev.js",

--- a/react/actions.js
+++ b/react/actions.js
@@ -1,6 +1,7 @@
 import {transaction} from "mobx";
 
 import ajax_requests from "./ajax_requests";
+import navigate from "./navigate";
 import taskState from "./state";
 
 
@@ -29,12 +30,13 @@ function deleteTask(task) {
 
     ajax_requests.post("/delete", data, () => {
         transaction(() => {
+            if (taskState.hierarchy.includes(task)) {
+                navigate.toTask(task.parent);
+            }
+
             let parent_children = task.parent.children;
             delete parent_children[task.id];
-
-            if (taskState.hierarchy.includes(task)) {
-                taskState.active_task = task.parent;
-            }
+            delete taskState.tasks_by_id[task.id];
         });
     });
 }

--- a/react/desktop_ui.js
+++ b/react/desktop_ui.js
@@ -1,7 +1,6 @@
 import DjangoCSRFToken from 'django-react-csrftoken';
 import {observer} from "mobx-react";
 import React from "react";
-import { ContextMenu, MenuItem } from "react-contextmenu";
 
 import taskState from "./state";
 import tab_container from "./tab_container";

--- a/react/main.js
+++ b/react/main.js
@@ -2,13 +2,12 @@
 require("../calcutron/static/styles/main.less");
 
 import $ from "jquery";
-import {observer} from "mobx-react";
 import React from "react";
 import ReactDOM from "react-dom";
 
 import ajax_requests from "./ajax_requests";
 import taskState from "./state";
-import DesktopUI from "./desktop_ui";
+import {BaseRoutedApp} from "./router";
 
 
 // Track the DOM element that React will be added to.
@@ -54,14 +53,6 @@ function stopHealthCheck() {
 }
 
 
-// Top-level app component.
-@observer class BaseApp extends React.Component {
-    render() {
-        return React.createElement(DesktopUI);
-    }
-}
-
-
 // Fill out the taskState and start up the React UI.
 function initialise() {
     // Grab the element we're injecting into.
@@ -80,7 +71,7 @@ function initialise() {
 
         // Create the React UI.
         saveScreenWidth();
-        ReactDOM.render(<BaseApp />, target);
+        ReactDOM.render(<BaseRoutedApp />, target);
 
         // Get the CSRF token we added, and store it in the state.
         taskState.csrf = $(target).children("input[name=csrfmiddlewaretoken]").val();

--- a/react/navigate.js
+++ b/react/navigate.js
@@ -14,7 +14,11 @@ export function setRouter(routerInstance) {
 }
 
 export function toTask(task) {
-    router.navigate("/" + task.id);
+    if (!task || task.id === null) {
+        router.navigate("/");
+    } else {
+        router.navigate("/" + task.id);
+    }
 }
 
 export default {

--- a/react/navigate.js
+++ b/react/navigate.js
@@ -1,0 +1,23 @@
+
+// This file exists to avoid circular imports between taskState and the router definition.
+// The router needs to call out to taskState to set the selected task, but actions that
+// are handled through the taskState also need to be able to navigate, and the only
+// way to do that is using the react hook (useNavigate) or directly via the router
+// (https://github.com/remix-run/react-router/issues/9422#issuecomment-1301182219).
+// I'm not keen on refactoring the codebase to hooks, so let's try a workaround.
+
+let router;
+
+// This is called (at import time) after defining the router in router.js.
+export function setRouter(routerInstance) {
+    router = routerInstance;
+}
+
+export function toTask(task) {
+    router.navigate("/" + task.id);
+}
+
+export default {
+    setRouter,
+    toTask,
+}

--- a/react/router.js
+++ b/react/router.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { observer } from "mobx-react";
+import { RouterProvider, createBrowserRouter } from "react-router-dom";
+
+import DesktopUI from "./desktop_ui";
+import navigate from "./navigate";
+import taskState from "./state";
+
+const router = createBrowserRouter([
+    {
+        path: "/:task_id?",
+        element: <DesktopUI />,
+        loader: ({ params }) => {
+            taskState.switchToTaskId(params.task_id);
+            return null;
+        },
+    },
+]);
+
+navigate.setRouter(router);
+
+
+// A top-level app component, with a route provider.
+@observer export class BaseRoutedApp extends React.Component {
+    render() {
+        return <RouterProvider router={router} />;
+    }
+}

--- a/react/tab_container.js
+++ b/react/tab_container.js
@@ -2,6 +2,7 @@ import {observer} from "mobx-react";
 import React from "react";
 
 import actions from "./actions";
+import navigate from "./navigate";
 import taskState from "./state";
 import SubtaskList from "./task";
 import AutoSizeTextarea from "./textarea";
@@ -31,7 +32,7 @@ import AutoSizeTextarea from "./textarea";
     }
 
     close() {
-        taskState.active_task = this.props.task.parent;
+        navigate.toTask(this.props.task.parent);
     }
 
     render() {

--- a/react/task.js
+++ b/react/task.js
@@ -1,9 +1,10 @@
 import $ from "jquery";
-import {observer} from "mobx-react";
+import { observer } from "mobx-react";
 import React from "react";
 import { ContextMenuTrigger } from "react-contextmenu";
 
 import actions from "./actions";
+import navigate from "./navigate";
 import taskState from "./state";
 import AutoSizeTextarea from "./textarea";
 
@@ -52,7 +53,7 @@ import AutoSizeTextarea from "./textarea";
     }
 
     activate() {
-        taskState.active_task = this.props.task;
+        navigate.toTask(this.props.task);
     }
 
     showEditMode() {


### PR DESCRIPTION
This was quite fiddly, and React Router doesn't really support class-based components any more, but it works now.

The application has a single route - `/:task_id?` - which sets the currently active task in `taskState`. The benefit of this is you can now directly link to specific tasks, and use the browser back/forward buttons to navigate (very useful for muscle memory on mobile).